### PR TITLE
Remove duplication and sort out github releated things

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,12 +1,16 @@
+
 buildscript {
+    ext {
+        axionPluginVersion = "1.2.0"
+        restPluginVersion = "0.3.2"
+        bintrayPluginVersion = "1.1"
+    }
     repositories {
-        mavenLocal()
         jcenter()
     }
     dependencies {
-        classpath "pl.allegro.tech.build:axion-release-plugin:1.2.0"
-        classpath "org._10ne.gradle:rest-gradle-plugin:0.3.2"
-        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.1'
+        classpath "pl.allegro.tech.build:axion-release-plugin:${axionPluginVersion}"
+        classpath "com.jfrog.bintray.gradle:gradle-bintray-plugin:${bintrayPluginVersion}"
     }
 }
 
@@ -41,10 +45,26 @@ dependencies {
     compile gradleApi()
     compile localGroovy()
 
-    compile "pl.allegro.tech.build:axion-release-plugin:1.2.0"
-    compile "org._10ne.gradle:rest-gradle-plugin:0.3.2"
-    compile 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.1'
+    compile "pl.allegro.tech.build:axion-release-plugin:${axionPluginVersion}"
+    compile "org._10ne.gradle:rest-gradle-plugin:${restPluginVersion}"
+    compile "com.jfrog.bintray.gradle:gradle-bintray-plugin:${bintrayPluginVersion}"
 
     testCompile 'org.spockframework:spock-core:0.7-groovy-2.0'
     testCompile 'junit:junit:4.11'
+}
+
+//Replace placeholders in files packages to JAR with the current versions
+processResources {
+    //expand cannot be used as it tries to resolve all placeholders
+    //filter with ReplaceTokens cannot be used as by default it uses '@' token and cannot be overridden (final class)
+    //TODO: Ugly hack - if you know a better way PR is welcome
+    filter { String line ->
+        String out = line
+        project.ext.getProperties().each { Map.Entry<String, Object> extProp ->
+            if (extProp.key.endsWith("Version") && out.contains('${' + extProp.key + '}')) {
+                out = line.replaceAll('\\$\\{' + extProp.key + '\\}', (String)(extProp.value)) //works better
+            }
+        }
+        return out
+    }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,7 @@ project.version = scmVersion.version
 apply plugin: 'groovy'
 apply from: 'src/main/resources/gradle/publish.gradle'
 apply from: 'src/main/resources/gradle/release.gradle'
+apply from: 'src/main/resources/gradle/github.gradle'
 
 bintray {
     pkg {

--- a/src/main/resources/gradle/github.gradle
+++ b/src/main/resources/gradle/github.gradle
@@ -1,0 +1,86 @@
+//To allow to use GrGit and RestTask classes as 'buildscript' closure has to be in every included file
+buildscript {
+    repositories {
+        jcenter()
+    }
+    dependencies {
+        classpath "pl.allegro.tech.build:axion-release-plugin:${axionPluginVersion}"
+        classpath "org._10ne.gradle:rest-gradle-plugin:${restPluginVersion}"
+        classpath "org.codehaus.groovy.modules.http-builder:http-builder:0.7.2" //to override old version in rest-gradle-plugin
+    }
+}
+
+import com.github.zafarkhaja.semver.Version
+
+task createReleaseInGitHub(type: org._10ne.gradle.rest.RestTask) {
+    dependsOn { releaseNeeded }
+    shouldRunAfter { bintrayUpload }
+    onlyIf { releaseNeeded.needed && !project.hasProperty('dryRun') }
+    httpMethod = 'post'
+    uri = "https://api.github.com/repos/4finance/${project.name}/releases"
+    requestHeaders = [Authorization: "token $ghToken"]
+    requestBody = [
+        tag_name: project.version,
+        name: project.version,
+        body:  "[Changes](https://github.com/4finance/${project.name}/issues?q=milestone%3A${project.version})".toString()
+    ]
+}
+
+task findCurrentGitHubMilestone(type: org._10ne.gradle.rest.RestTask) {
+    dependsOn { releaseNeeded }
+//    onlyIf { releaseNeeded.needed && !project.hasProperty('dryRun') }
+    uri = "https://api.github.com/repos/4finance/${project.name}/milestones?state=open"
+    requestHeaders = [:]
+    doLast {
+        def matchingMilestones = serverResponse.data.grep({ it.title == project.version })
+        ext.gitHubMilestoneNumber = matchingMilestones.empty ? 0 : matchingMilestones.first().number
+        logger.info("Received current GitHub milestone: ${ext.gitHubMilestoneNumber}")
+    }
+}
+
+task createNextGitHubMilestone(type: org._10ne.gradle.rest.RestTask) {
+    dependsOn { [releaseNeeded, findCurrentGitHubMilestone] }
+    shouldRunAfter { bintrayUpload }
+    onlyIf { releaseNeeded.needed && !project.hasProperty('dryRun') && findCurrentGitHubMilestone.gitHubMilestoneNumber }
+    httpMethod = 'post'
+    uri = "https://api.github.com/repos/4finance/${project.name}/milestones"
+    requestHeaders = [Authorization: ghToken]
+    requestBody = [
+        title: Version.valueOf(project.version).incrementPatchVersion().toString()
+    ]
+}
+
+task closeMilestoneBeingReleased(type: org._10ne.gradle.rest.RestTask) {
+    dependsOn { [releaseNeeded, findCurrentGitHubMilestone] }
+    shouldRunAfter { bintrayUpload }
+    onlyIf { releaseNeeded.needed && !project.hasProperty('dryRun') && findCurrentGitHubMilestone.gitHubMilestoneNumber }
+    httpMethod = 'patch'
+    uri = "broken-should-be-overridden-in-do-frst"
+    requestHeaders = [Authorization: "token $ghToken"]
+    requestBody = [
+        title: project.version,
+        state: 'closed'
+    ]
+    doFirst {
+        uri = "https://api.github.com/repos/4finance/${project.name}/milestones/${findCurrentGitHubMilestone.gitHubMilestoneNumber}"
+    }
+}
+
+configure([createReleaseInGitHub, findCurrentGitHubMilestone, closeMilestoneBeingReleased, createNextGitHubMilestone]) {
+    requestHeaders += ['User-Agent': 'https://github.com/4finance/micro-common-release']
+    contentType = groovyx.net.http.ContentType.JSON
+}
+
+task gitHubRelease {
+    //TODO: Disabled due to https://github.com/4finance/micro-common-release/issues/12
+    dependsOn { [releaseNeeded, /*createReleaseInGitHub,*/ closeMilestoneBeingReleased /*, createNextGitHubMilestone */] }
+    shouldRunAfter { bintrayUpload }
+    onlyIf { releaseNeeded.needed }
+    doLast {
+        if (dryRun) {
+            logger.lifecycle "Dry-running gitHubRelease"
+        }
+    }
+}
+
+finalizeRelease.dependsOn { gitHubRelease }

--- a/src/main/resources/gradle/release.gradle
+++ b/src/main/resources/gradle/release.gradle
@@ -5,6 +5,9 @@ assert project == rootProject
 
 //To allow to use GrGit and RestTask classes as 'buildscript' closure has to be in every included file
 buildscript {
+    ext {
+        ghToken = System.env.GH_TOKEN ?: "" //Here to be visible also in github.gradle
+    }
     repositories {
         jcenter()
     }
@@ -17,7 +20,6 @@ buildscript {
 
 def dryRun = project.hasProperty('dryRun')
 def branch = System.env.TRAVIS_BRANCH
-def ghToken = System.env.GH_TOKEN ?: ""
 def ghUser = System.env.GH_USER ?: "4financeBot"
 boolean localRelease = project.hasProperty("localRelease")
 boolean isTriggerInCommit = isReleaseTriggerInLastCommitMessage(localRelease)
@@ -57,84 +59,13 @@ release {
     }
 }
 
-task createReleaseInGitHub(type: org._10ne.gradle.rest.RestTask) {
-    dependsOn { releaseNeeded }
-    shouldRunAfter { bintrayUpload }
-    onlyIf { releaseNeeded.needed && !project.hasProperty('dryRun') }
-    httpMethod = 'post'
-    uri = "https://api.github.com/repos/4finance/${project.name}/releases"
-    requestHeaders = [Authorization: "token $ghToken"]
-    requestBody = [
-        tag_name: project.version,
-        name: project.version,
-        body:  "[Changes](https://github.com/4finance/${project.name}/issues?q=milestone%3A${project.version})".toString()
-    ]
-}
-
-import com.github.zafarkhaja.semver.Version
 import org.ajoberstar.grgit.Commit
 import org.ajoberstar.grgit.Credentials
 import org.ajoberstar.grgit.Grgit
 
-task findCurrentGitHubMilestone(type: org._10ne.gradle.rest.RestTask) {
-    dependsOn { releaseNeeded }
-    onlyIf { releaseNeeded.needed && !project.hasProperty('dryRun') }
-    uri = "https://api.github.com/repos/4finance/${project.name}/milestones?state=open"
-    requestHeaders = [:]
-    doLast {
-        def matchingMilestones = serverResponse.data.grep({ it.title == project.version })
-        ext.gitHubMilestoneNumber = matchingMilestones.empty ? 0 : matchingMilestones.first().number
-        logger.info("Received current GitHub milestone: ${ext.gitHubMilestoneNumber}")
-    }
-}
-
-task createNextGitHubMilestone(type: org._10ne.gradle.rest.RestTask) {
-    dependsOn { [releaseNeeded, findCurrentGitHubMilestone] }
-    shouldRunAfter { bintrayUpload }
-    onlyIf { releaseNeeded.needed && !project.hasProperty('dryRun') && findCurrentGitHubMilestone.gitHubMilestoneNumber }
-    httpMethod = 'post'
-    uri = "https://api.github.com/repos/4finance/${project.name}/milestones"
-    requestHeaders = [Authorization: ghToken]
-    requestBody = [
-        title: Version.valueOf(project.version).incrementPatchVersion().toString()
-    ]
-}
-
-task closeMilestoneBeingReleased(type: org._10ne.gradle.rest.RestTask) {
-    dependsOn { [releaseNeeded, findCurrentGitHubMilestone] }
-    shouldRunAfter { bintrayUpload }
-    onlyIf { releaseNeeded.needed && !project.hasProperty('dryRun') && findCurrentGitHubMilestone.gitHubMilestoneNumber }
-    httpMethod = 'patch'
-    uri = "broken-should-be-overridden-in-do-frst"
-    requestHeaders = [Authorization: "token $ghToken"]
-    requestBody = [
-        title: project.version,
-        state: 'closed'
-    ]
-    doFirst {
-        uri = "https://api.github.com/repos/4finance/${project.name}/milestones/${findCurrentGitHubMilestone.gitHubMilestoneNumber}"
-    }
-}
-
-configure([createReleaseInGitHub, findCurrentGitHubMilestone, closeMilestoneBeingReleased, createNextGitHubMilestone]) {
-    requestHeaders += ['User-Agent': 'https://github.com/4finance/micro-common-release']
-    contentType = groovyx.net.http.ContentType.JSON
-}
-
-task gitHubRelease {
-    //TODO: Disabled due to https://github.com/4finance/micro-common-release/issues/12
-    dependsOn { [releaseNeeded, /*createReleaseInGitHub,*/ closeMilestoneBeingReleased /*, createNextGitHubMilestone */] }
-    shouldRunAfter { bintrayUpload }
-    onlyIf { releaseNeeded.needed }
-    doLast {
-        if (dryRun) {
-            logger.lifecycle "Dry-running gitHubRelease"
-        }
-    }
-}
 
 task("finalizeRelease") {
-    dependsOn { [uploadableProjects.bintrayUpload, releaseNeeded, gitHubRelease] }
+    dependsOn { [uploadableProjects.bintrayUpload, releaseNeeded] }
     onlyIf { releaseNeeded.needed }
     doLast {
         if (dryRun) {

--- a/src/main/resources/gradle/release.gradle
+++ b/src/main/resources/gradle/release.gradle
@@ -38,7 +38,7 @@ task("releaseNeeded") {
 Set uploadableProjects = allprojects.findAll { sProject -> sProject.tasks.matching { it.name == "bintrayUpload" }}
 
 uploadableProjects*.bintrayUpload {
-    dependsOn releaseNeeded
+    dependsOn { releaseNeeded }
     onlyIf { releaseNeeded.needed }
     doFirst {
         if (dryRun) {
@@ -48,7 +48,7 @@ uploadableProjects*.bintrayUpload {
 }
 
 release {
-    dependsOn releaseNeeded
+    dependsOn { releaseNeeded }
     onlyIf { releaseNeeded.needed }
     doFirst {
         if (dryRun) {
@@ -58,8 +58,8 @@ release {
 }
 
 task createReleaseInGitHub(type: org._10ne.gradle.rest.RestTask) {
-    dependsOn releaseNeeded
-    shouldRunAfter bintrayUpload
+    dependsOn { releaseNeeded }
+    shouldRunAfter { bintrayUpload }
     onlyIf { releaseNeeded.needed && !project.hasProperty('dryRun') }
     httpMethod = 'post'
     uri = "https://api.github.com/repos/4finance/${project.name}/releases"
@@ -71,14 +71,13 @@ task createReleaseInGitHub(type: org._10ne.gradle.rest.RestTask) {
     ]
 }
 
-
 import com.github.zafarkhaja.semver.Version
 import org.ajoberstar.grgit.Commit
 import org.ajoberstar.grgit.Credentials
 import org.ajoberstar.grgit.Grgit
 
 task findCurrentGitHubMilestone(type: org._10ne.gradle.rest.RestTask) {
-    dependsOn releaseNeeded
+    dependsOn { releaseNeeded }
     onlyIf { releaseNeeded.needed && !project.hasProperty('dryRun') }
     uri = "https://api.github.com/repos/4finance/${project.name}/milestones?state=open"
     requestHeaders = [:]
@@ -90,8 +89,8 @@ task findCurrentGitHubMilestone(type: org._10ne.gradle.rest.RestTask) {
 }
 
 task createNextGitHubMilestone(type: org._10ne.gradle.rest.RestTask) {
-    dependsOn releaseNeeded, findCurrentGitHubMilestone
-    shouldRunAfter bintrayUpload
+    dependsOn { [releaseNeeded, findCurrentGitHubMilestone] }
+    shouldRunAfter { bintrayUpload }
     onlyIf { releaseNeeded.needed && !project.hasProperty('dryRun') && findCurrentGitHubMilestone.gitHubMilestoneNumber }
     httpMethod = 'post'
     uri = "https://api.github.com/repos/4finance/${project.name}/milestones"
@@ -102,8 +101,8 @@ task createNextGitHubMilestone(type: org._10ne.gradle.rest.RestTask) {
 }
 
 task closeMilestoneBeingReleased(type: org._10ne.gradle.rest.RestTask) {
-    dependsOn releaseNeeded, findCurrentGitHubMilestone
-    shouldRunAfter bintrayUpload
+    dependsOn { [releaseNeeded, findCurrentGitHubMilestone] }
+    shouldRunAfter { bintrayUpload }
     onlyIf { releaseNeeded.needed && !project.hasProperty('dryRun') && findCurrentGitHubMilestone.gitHubMilestoneNumber }
     httpMethod = 'patch'
     uri = "broken-should-be-overridden-in-do-frst"
@@ -124,8 +123,8 @@ configure([createReleaseInGitHub, findCurrentGitHubMilestone, closeMilestoneBein
 
 task gitHubRelease {
     //TODO: Disabled due to https://github.com/4finance/micro-common-release/issues/12
-    dependsOn releaseNeeded, /*createReleaseInGitHub,*/ closeMilestoneBeingReleased /*, createNextGitHubMilestone */
-    shouldRunAfter bintrayUpload
+    dependsOn { [releaseNeeded, /*createReleaseInGitHub,*/ closeMilestoneBeingReleased /*, createNextGitHubMilestone */] }
+    shouldRunAfter { bintrayUpload }
     onlyIf { releaseNeeded.needed }
     doLast {
         if (dryRun) {
@@ -135,7 +134,7 @@ task gitHubRelease {
 }
 
 task("finalizeRelease") {
-    dependsOn uploadableProjects.bintrayUpload, releaseNeeded, gitHubRelease
+    dependsOn { [uploadableProjects.bintrayUpload, releaseNeeded, gitHubRelease] }
     onlyIf { releaseNeeded.needed }
     doLast {
         if (dryRun) {
@@ -162,8 +161,8 @@ task("finalizeRelease") {
 
 configure(uploadableProjects) {
     task publishUploadedArtifacts(type: org._10ne.gradle.rest.RestTask) {
-        dependsOn releaseNeeded
-        mustRunAfter finalizeRelease
+        dependsOn { releaseNeeded }
+        mustRunAfter { finalizeRelease }
         onlyIf { releaseNeeded.needed && !project.hasProperty('dryRun') }   //TODO: Not available in rest-gradle-plugin yet - https://github.com/noamt/rest-gradle-plugin/issues/9
         httpMethod = 'post'
         uri = "broken-should-be-overridden-in-do-frst"

--- a/src/main/resources/gradle/release.gradle
+++ b/src/main/resources/gradle/release.gradle
@@ -6,12 +6,11 @@ assert project == rootProject
 //To allow to use GrGit and RestTask classes as 'buildscript' closure has to be in every included file
 buildscript {
     repositories {
-        mavenLocal()
         jcenter()
     }
     dependencies {
-        classpath "pl.allegro.tech.build:axion-release-plugin:1.2.0"
-        classpath "org._10ne.gradle:rest-gradle-plugin:0.3.2"
+        classpath "pl.allegro.tech.build:axion-release-plugin:${axionPluginVersion}"
+        classpath "org._10ne.gradle:rest-gradle-plugin:${restPluginVersion}"
         classpath "org.codehaus.groovy.modules.http-builder:http-builder:0.7.2" //to override old version in rest-gradle-plugin
     }
 }
@@ -86,6 +85,7 @@ task findCurrentGitHubMilestone(type: org._10ne.gradle.rest.RestTask) {
     doLast {
         def matchingMilestones = serverResponse.data.grep({ it.title == project.version })
         ext.gitHubMilestoneNumber = matchingMilestones.empty ? 0 : matchingMilestones.first().number
+        logger.info("Received current GitHub milestone: ${ext.gitHubMilestoneNumber}")
     }
 }
 


### PR DESCRIPTION
GitHub release related tasks are not enabled by default as they are mostly broken due to #12. They were extracted to a separate file which has to be applied separately.

Btw, if you know how to elimitane "ugle hack" with resource filtering do not hesitate to write.

Side note. It is harder and harder to work with GitHub limitations when the code is not written as a plugin, but only a set of Gradle script. By the way on the next big changes it would be good to consider conversion into a separate plugin.